### PR TITLE
Add server-driven round timer with auto-submit on expiry

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -20,6 +20,15 @@ app.use(express.json());
 const games = new Map();
 const players = new Map();
 
+// Blank white 1x1 PNG as data URL for auto-submitted drawings
+const BLANK_CANVAS_DATA_URL = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwADhQGAWjR9awAAAABJRU5ErkJggg==';
+
+// Strip server-only fields before sending game state to clients
+function sanitizeGameForClient(game) {
+  const { activeTimers, ...rest } = game;
+  return rest;
+}
+
 // Generate random game code
 function generateGameCode() {
   const chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
@@ -30,21 +39,97 @@ function generateGameCode() {
   return code;
 }
 
+// Advance to next round or end the game
+function advanceRoundOrEnd(gameCode) {
+  const game = games.get(gameCode);
+  if (!game) return;
+
+  if (game.currentRound < game.maxRounds) {
+    game.currentRound++;
+    io.to(gameCode).emit('nextRound', {
+      game: sanitizeGameForClient(game),
+      round: game.currentRound
+    });
+    startRoundTimer(gameCode, game.currentRound);
+  } else {
+    game.status = 'COMPLETED';
+    Object.values(game.activeTimers || {}).forEach(id => clearInterval(id));
+    game.activeTimers = {};
+    io.to(gameCode).emit('gameComplete', {
+      game: sanitizeGameForClient(game),
+      submissions: game.submissions
+    });
+  }
+}
+
+// Auto-submit placeholder entries for players who haven't submitted yet
+function autoSubmitMissingPlayers(gameCode, roundNumber) {
+  const game = games.get(gameCode);
+  if (!game || game.currentRound !== roundNumber) return;
+
+  const roundSubmissions = game.submissions.filter(s => s.round === roundNumber);
+  const submittedPlayerIds = new Set(roundSubmissions.map(s => s.playerId));
+  const isTextRound = roundNumber % 2 === 1;
+
+  for (const player of game.players) {
+    if (!submittedPlayerIds.has(player.id)) {
+      game.submissions.push({
+        id: uuidv4(),
+        playerId: player.id,
+        playerName: player.name,
+        round: roundNumber,
+        type: isTextRound ? 'TEXT' : 'DRAWING',
+        content: isTextRound ? '(time ran out)' : 'Time ran out',
+        imageData: isTextRound ? null : BLANK_CANVAS_DATA_URL,
+        submittedAt: new Date().toISOString(),
+        autoSubmitted: true
+      });
+    }
+  }
+
+  advanceRoundOrEnd(gameCode);
+}
+
+// Start server-driven round timer
+function startRoundTimer(gameCode, roundNumber) {
+  const game = games.get(gameCode);
+  if (!game || !game.timerDuration) return;
+
+  let secondsLeft = game.timerDuration;
+
+  // Emit immediately so clients show full timer on round start
+  io.to(gameCode).emit('timerUpdate', { secondsLeft, roundNumber });
+
+  const intervalId = setInterval(() => {
+    secondsLeft--;
+    io.to(gameCode).emit('timerUpdate', { secondsLeft, roundNumber });
+
+    if (secondsLeft <= 0) {
+      clearInterval(intervalId);
+      delete game.activeTimers[roundNumber];
+      autoSubmitMissingPlayers(gameCode, roundNumber);
+    }
+  }, 1000);
+
+  game.activeTimers[roundNumber] = intervalId;
+}
+
 // REST API endpoints
 app.get('/api/health', (req, res) => {
   res.json({ status: 'ok', games: games.size, players: players.size });
 });
 
 app.post('/api/game/create', (req, res) => {
-  const { hostName, maxRounds, minPlayers } = req.body;
+  const { hostName, maxRounds, minPlayers, timerDuration } = req.body;
 
-  // Validation
   if (!hostName || !hostName.trim()) {
     return res.status(400).json({ error: 'Host name is required' });
   }
 
   const validatedMaxRounds = maxRounds && maxRounds >= 3 && maxRounds <= 10 ? maxRounds : 6;
   const validatedMinPlayers = minPlayers && minPlayers >= 2 && minPlayers <= 10 ? minPlayers : 3;
+  const validTimerValues = [30, 60, 90, 120];
+  const validatedTimerDuration = validTimerValues.includes(timerDuration) ? timerDuration : null;
 
   const gameCode = generateGameCode();
   const gameId = uuidv4();
@@ -57,13 +142,15 @@ app.post('/api/game/create', (req, res) => {
     currentRound: 0,
     maxRounds: validatedMaxRounds,
     minPlayers: validatedMinPlayers,
+    timerDuration: validatedTimerDuration,
     players: [],
     submissions: [],
+    activeTimers: {},
     createdAt: new Date().toISOString()
   };
 
   games.set(gameCode, game);
-  res.json({ game });
+  res.json({ game: sanitizeGameForClient(game) });
 });
 
 app.get('/api/game/:code', (req, res) => {
@@ -71,7 +158,7 @@ app.get('/api/game/:code', (req, res) => {
   if (!game) {
     return res.status(404).json({ error: 'Game not found' });
   }
-  res.json({ game });
+  res.json({ game: sanitizeGameForClient(game) });
 });
 
 // Socket.IO connection handling
@@ -80,7 +167,6 @@ io.on('connection', (socket) => {
 
   // Join game
   socket.on('joinGame', ({ gameCode, playerName }) => {
-    // Validation
     if (!gameCode || !gameCode.trim()) {
       socket.emit('error', { message: 'Game code is required' });
       return;
@@ -103,7 +189,6 @@ io.on('connection', (socket) => {
       return;
     }
 
-    // Check if player name is already taken
     const nameExists = game.players.some(p => p.name.toLowerCase() === playerName.trim().toLowerCase());
     if (nameExists) {
       socket.emit('error', { message: 'This name is already taken. Please choose a different name.' });
@@ -131,10 +216,8 @@ io.on('connection', (socket) => {
 
     socket.join(gameCode.toUpperCase());
 
-    // Send player info to the joining player
-    socket.emit('playerJoined', { player, game });
+    socket.emit('playerJoined', { player, game: sanitizeGameForClient(game) });
 
-    // Notify all players in the game
     io.to(gameCode.toUpperCase()).emit('playersUpdate', {
       players: game.players
     });
@@ -171,7 +254,8 @@ io.on('connection', (socket) => {
     game.status = 'IN_PROGRESS';
     game.currentRound = 1;
 
-    io.to(gameCode.toUpperCase()).emit('gameStarted', { game });
+    io.to(gameCode.toUpperCase()).emit('gameStarted', { game: sanitizeGameForClient(game) });
+    startRoundTimer(gameCode.toUpperCase(), 1);
     console.log(`Game ${gameCode} started with ${game.players.length} players`);
   });
 
@@ -190,7 +274,7 @@ io.on('connection', (socket) => {
       playerId: player.id,
       playerName: player.name,
       round: game.currentRound,
-      type: type, // 'TEXT' or 'DRAWING'
+      type: type,
       content: content,
       imageData: imageData,
       submittedAt: new Date().toISOString()
@@ -198,27 +282,17 @@ io.on('connection', (socket) => {
 
     game.submissions.push(submission);
 
-    // Check if all players have submitted for this round
     const roundSubmissions = game.submissions.filter(s => s.round === game.currentRound);
 
     if (roundSubmissions.length === game.players.length) {
-      // Move to next round
-      if (game.currentRound < game.maxRounds) {
-        game.currentRound++;
-        io.to(gameCode.toUpperCase()).emit('nextRound', {
-          game,
-          round: game.currentRound
-        });
-      } else {
-        // Game complete
-        game.status = 'COMPLETED';
-        io.to(gameCode.toUpperCase()).emit('gameComplete', {
-          game,
-          submissions: game.submissions
-        });
+      // All players submitted - cancel timer early if running
+      const timerId = game.activeTimers[game.currentRound];
+      if (timerId) {
+        clearInterval(timerId);
+        delete game.activeTimers[game.currentRound];
       }
+      advanceRoundOrEnd(gameCode.toUpperCase());
     } else {
-      // Notify that a submission was received
       io.to(gameCode.toUpperCase()).emit('submissionReceived', {
         playerName: player.name,
         submitted: roundSubmissions.length,
@@ -239,7 +313,6 @@ io.on('connection', (socket) => {
       return;
     }
 
-    // Get the previous player's submission from the previous round
     const previousRound = game.currentRound - 1;
     if (previousRound > 0) {
       const previousPlayerOrder = (player.order - 1 + game.players.length) % game.players.length;
@@ -267,7 +340,7 @@ io.on('connection', (socket) => {
     }
 
     socket.emit('gameResults', {
-      game,
+      game: sanitizeGameForClient(game),
       submissions: game.submissions,
       players: game.players
     });
@@ -281,23 +354,21 @@ io.on('connection', (socket) => {
       const game = games.get(player.gameCode);
 
       if (game) {
-        // Remove player from game
         game.players = game.players.filter(p => p.id !== player.id);
 
-        // Notify remaining players
         io.to(player.gameCode).emit('playerLeft', {
           playerName: player.name,
           players: game.players
         });
 
-        // If game is empty, delete it after 1 hour
         if (game.players.length === 0) {
           setTimeout(() => {
             if (games.get(player.gameCode)?.players.length === 0) {
+              Object.values(game.activeTimers || {}).forEach(id => clearInterval(id));
               games.delete(player.gameCode);
               console.log(`Deleted empty game ${player.gameCode}`);
             }
-          }, 3600000); // 1 hour
+          }, 3600000);
         }
       }
 
@@ -315,11 +386,12 @@ setInterval(() => {
   for (const [code, game] of games.entries()) {
     const createdAt = new Date(game.createdAt).getTime();
     if (createdAt < oneHourAgo && game.players.length === 0) {
+      Object.values(game.activeTimers || {}).forEach(id => clearInterval(id));
       games.delete(code);
       console.log(`Cleaned up old game ${code}`);
     }
   }
-}, 3600000); // Run every hour
+}, 3600000);
 
 const PORT = process.env.PORT || 5000;
 server.listen(PORT, () => {

--- a/src/components/game.component.js
+++ b/src/components/game.component.js
@@ -22,6 +22,8 @@ export default function Game() {
     const [loading, setLoading] = useState(true);
     const [error, setError] = useState('');
     const [submittedCount, setSubmittedCount] = useState(0);
+    const [secondsLeft, setSecondsLeft] = useState(null);
+    const [timerDuration, setTimerDuration] = useState(null);
 
     useEffect(() => {
         if (!socket) return;
@@ -70,7 +72,12 @@ export default function Game() {
 
         socket.on('gameStarted', ({ game: updatedGame }) => {
             setGame(updatedGame);
+            setTimerDuration(updatedGame.timerDuration || null);
             socket.emit('getPreviousSubmission', { gameCode: code });
+        });
+
+        socket.on('timerUpdate', ({ secondsLeft: sLeft, roundNumber }) => {
+            setSecondsLeft(sLeft);
         });
 
         socket.on('previousSubmission', ({ submission }) => {
@@ -87,6 +94,7 @@ export default function Game() {
             setPreviousSubmission(null);
             setIsSubmitting(false);
             setSubmittedCount(0);
+            setSecondsLeft(null);
             clearCanvas();
             socket.emit('getPreviousSubmission', { gameCode: code });
         });
@@ -113,6 +121,7 @@ export default function Game() {
             socket.off('playerJoined');
             socket.off('playersUpdate');
             socket.off('gameStarted');
+            socket.off('timerUpdate');
             socket.off('previousSubmission');
             socket.off('submissionReceived');
             socket.off('nextRound');
@@ -361,9 +370,27 @@ export default function Game() {
             <Col lg={9}>
                 <Card className="shadow">
                     <Card.Body>
-                        <h3 className="mb-4">
-                            {isCurrentPlayerTurn ? '📝 Write Your Phrase' : '🎨 Draw What You See'}
-                        </h3>
+                        <div className="d-flex justify-content-between align-items-center mb-4">
+                            <h3 className="mb-0">
+                                {isCurrentPlayerTurn ? '📝 Write Your Phrase' : '🎨 Draw What You See'}
+                            </h3>
+                            {timerDuration && secondsLeft !== null && (
+                                <div className="text-end" style={{ minWidth: '120px' }}>
+                                    <div className={`fw-bold fs-4 ${secondsLeft <= 10 ? 'text-danger' : 'text-dark'}`}>
+                                        ⏱ {secondsLeft > 0 ? `${secondsLeft}s` : 'Time\'s up!'}
+                                    </div>
+                                    <div style={{ height: '6px', background: '#dee2e6', borderRadius: '3px', marginTop: '4px' }}>
+                                        <div style={{
+                                            height: '100%',
+                                            width: `${Math.max(0, (secondsLeft / timerDuration) * 100)}%`,
+                                            background: secondsLeft <= 10 ? '#dc3545' : '#0d6efd',
+                                            borderRadius: '3px',
+                                            transition: 'width 1s linear'
+                                        }} />
+                                    </div>
+                                </div>
+                            )}
+                        </div>
 
                         {previousSubmission && (
                             <Alert variant="info">

--- a/src/components/newGame.component.js
+++ b/src/components/newGame.component.js
@@ -15,6 +15,7 @@ export default function NewGame() {
     const [gameCreated, setGameCreated] = useState(false);
     const [maxRounds, setMaxRounds] = useState(6);
     const [minPlayers, setMinPlayers] = useState(3);
+    const [timerDuration, setTimerDuration] = useState(null);
     const [currentPlayer, setCurrentPlayer] = useState(null);
     const [errorMessage, setErrorMessage] = useState('');
 
@@ -102,7 +103,8 @@ export default function NewGame() {
                 body: JSON.stringify({
                     hostName: playerName.trim(),
                     maxRounds: maxRounds,
-                    minPlayers: minPlayers
+                    minPlayers: minPlayers,
+                    timerDuration: timerDuration
                 })
             });
 
@@ -207,6 +209,23 @@ export default function NewGame() {
                                 />
                                 <Form.Text className="text-muted">
                                     Minimum number of players required to start the game (2-10)
+                                </Form.Text>
+                            </Form.Group>
+
+                            <Form.Group className="mb-4">
+                                <Form.Label>Round Timer</Form.Label>
+                                <Form.Select
+                                    value={timerDuration === null ? 'off' : timerDuration}
+                                    onChange={(e) => setTimerDuration(e.target.value === 'off' ? null : parseInt(e.target.value))}
+                                >
+                                    <option value="off">Off (no limit)</option>
+                                    <option value="30">30 seconds</option>
+                                    <option value="60">60 seconds</option>
+                                    <option value="90">90 seconds</option>
+                                    <option value="120">120 seconds</option>
+                                </Form.Select>
+                                <Form.Text className="text-muted">
+                                    Auto-submits when time runs out
                                 </Form.Text>
                             </Form.Group>
 


### PR DESCRIPTION
- Server tracks timerDuration per game, emits timerUpdate every second
- Auto-submits placeholder entries for players who miss the deadline
- Timer cancels early if all players submit before time runs out
- Frontend shows countdown with progress bar, turns red at 10s
- Host can configure 30/60/90/120s or off when creating game