### PR TITLE
Add theme/word prompt suggestions for round 1

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -120,7 +120,7 @@ app.get('/api/health', (req, res) => {
 });
 
 app.post('/api/game/create', (req, res) => {
-  const { hostName, maxRounds, minPlayers, timerDuration } = req.body;
+  const { hostName, maxRounds, minPlayers, timerDuration, prompts } = req.body;
 
   if (!hostName || !hostName.trim()) {
     return res.status(400).json({ error: 'Host name is required' });
@@ -130,6 +130,16 @@ app.post('/api/game/create', (req, res) => {
   const validatedMinPlayers = minPlayers && minPlayers >= 2 && minPlayers <= 10 ? minPlayers : 3;
   const validTimerValues = [30, 60, 90, 120];
   const validatedTimerDuration = validTimerValues.includes(timerDuration) ? timerDuration : null;
+
+  // Parse prompts: accept comma or newline separated string
+  let validatedPrompts = [];
+  if (typeof prompts === 'string' && prompts.trim()) {
+    validatedPrompts = prompts
+      .split(/[\n,]/)
+      .map(s => s.trim())
+      .filter(s => s.length > 0 && s.length <= 100)
+      .slice(0, 50);
+  }
 
   const gameCode = generateGameCode();
   const gameId = uuidv4();
@@ -143,6 +153,7 @@ app.post('/api/game/create', (req, res) => {
     maxRounds: validatedMaxRounds,
     minPlayers: validatedMinPlayers,
     timerDuration: validatedTimerDuration,
+    prompts: validatedPrompts,
     players: [],
     submissions: [],
     activeTimers: {},
@@ -253,6 +264,14 @@ io.on('connection', (socket) => {
 
     game.status = 'IN_PROGRESS';
     game.currentRound = 1;
+
+    // Assign random prompt suggestions to players if prompts are configured
+    if (game.prompts && game.prompts.length > 0) {
+      const shuffled = [...game.prompts].sort(() => Math.random() - 0.5);
+      game.players.forEach((player, i) => {
+        player.promptSuggestion = shuffled[i % shuffled.length];
+      });
+    }
 
     io.to(gameCode.toUpperCase()).emit('gameStarted', { game: sanitizeGameForClient(game) });
     startRoundTimer(gameCode.toUpperCase(), 1);

--- a/src/components/game.component.js
+++ b/src/components/game.component.js
@@ -24,6 +24,8 @@ export default function Game() {
     const [submittedCount, setSubmittedCount] = useState(0);
     const [secondsLeft, setSecondsLeft] = useState(null);
     const [timerDuration, setTimerDuration] = useState(null);
+    const [promptSuggestion, setPromptSuggestion] = useState(null);
+    const [promptDismissed, setPromptDismissed] = useState(false);
 
     useEffect(() => {
         if (!socket) return;
@@ -73,6 +75,12 @@ export default function Game() {
         socket.on('gameStarted', ({ game: updatedGame }) => {
             setGame(updatedGame);
             setTimerDuration(updatedGame.timerDuration || null);
+            // Find prompt suggestion for current player
+            const self = updatedGame.players.find(p => p.socketId === socket.id);
+            if (self?.promptSuggestion) {
+                setPromptSuggestion(self.promptSuggestion);
+                setPromptDismissed(false);
+            }
             socket.emit('getPreviousSubmission', { gameCode: code });
         });
 
@@ -95,6 +103,8 @@ export default function Game() {
             setIsSubmitting(false);
             setSubmittedCount(0);
             setSecondsLeft(null);
+            setPromptSuggestion(null);
+            setPromptDismissed(false);
             clearCanvas();
             socket.emit('getPreviousSubmission', { gameCode: code });
         });
@@ -414,6 +424,13 @@ export default function Game() {
                             <>
                                 {isCurrentPlayerTurn ? (
                                     <div>
+                                        {promptSuggestion && !promptDismissed && game.currentRound === 1 && (
+                                            <Alert variant="warning" dismissible onClose={() => setPromptDismissed(true)} className="mb-3">
+                                                <strong>💡 Prompt suggestion:</strong> "{promptSuggestion}"
+                                                <br />
+                                                <small className="text-muted">Feel free to use this or write your own phrase.</small>
+                                            </Alert>
+                                        )}
                                         <Form.Group className="mb-3">
                                             <Form.Label>
                                                 {game.currentRound === 1

--- a/src/components/newGame.component.js
+++ b/src/components/newGame.component.js
@@ -16,6 +16,7 @@ export default function NewGame() {
     const [maxRounds, setMaxRounds] = useState(6);
     const [minPlayers, setMinPlayers] = useState(3);
     const [timerDuration, setTimerDuration] = useState(null);
+    const [prompts, setPrompts] = useState('');
     const [currentPlayer, setCurrentPlayer] = useState(null);
     const [errorMessage, setErrorMessage] = useState('');
 
@@ -104,7 +105,8 @@ export default function NewGame() {
                     hostName: playerName.trim(),
                     maxRounds: maxRounds,
                     minPlayers: minPlayers,
-                    timerDuration: timerDuration
+                    timerDuration: timerDuration,
+                    prompts: prompts
                 })
             });
 
@@ -226,6 +228,20 @@ export default function NewGame() {
                                 </Form.Select>
                                 <Form.Text className="text-muted">
                                     Auto-submits when time runs out
+                                </Form.Text>
+                            </Form.Group>
+
+                            <Form.Group className="mb-4">
+                                <Form.Label>Theme / Word Prompts <span className="text-muted fw-normal">(optional)</span></Form.Label>
+                                <Form.Control
+                                    as="textarea"
+                                    rows={4}
+                                    placeholder={"A dog flying a kite\nThe moon made of cheese\nA wizard doing laundry"}
+                                    value={prompts}
+                                    onChange={(e) => setPrompts(e.target.value)}
+                                />
+                                <Form.Text className="text-muted">
+                                    One prompt per line (or comma-separated). Each player gets a random suggestion in round 1 — they can use it or write their own.
                                 </Form.Text>
                             </Form.Group>
 


### PR DESCRIPTION
- Host can enter prompts (one per line or comma-separated) when creating game
- Server assigns a random prompt to each player on game start
- Players see a dismissible suggestion alert in round 1 text entry
- Prompts are optional - players can always write their own phrase